### PR TITLE
Update index.ts

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,4 +11,6 @@ export * from './logger';
 // Export linker
 export * from './Linker';
 
+export * from './DataBinder';
+
 // Add any other core exports here


### PR DESCRIPTION
This fork adds the missing DataBinder export in core/index.ts to allow direct usage from the package root.